### PR TITLE
feat(astrolabe): persist controls drawer state to localStorage

### DIFF
--- a/src/components/astrolabe/controls.ts
+++ b/src/components/astrolabe/controls.ts
@@ -20,6 +20,83 @@ const EARTH_MODE_BY_VALUE: Record<string, EarthMode> = {
 
 const DEFAULT_MATERIAL: MaterialId = "platinum";
 
+// Namespaced + versioned localStorage key for the controls-drawer snapshot.
+const STORAGE_KEY = "astrolabe.controls.v1";
+
+// The persisted shape: per-control DOM state addressed by DOM handle. No
+// simulation fields (simT/bootMs/caseOffset/seeds) ever appear here.
+interface ControlSnapshot {
+	inputs: Record<string, string | boolean>; // element id -> value | checked
+	groups: Record<string, string>; // group id -> dataset.value
+	material: string; // selected material id
+	colors: Record<string, string>; // data-var -> picker value
+}
+
+// Keep only the string-valued entries of an unknown blob. A non-object (or a
+// nested non-string value from a tampered/stale store) yields an empty map.
+function parseStringMap(v: unknown): Record<string, string> {
+	const out: Record<string, string> = {};
+	if (typeof v === "object" && v !== null) {
+		for (const [k, val] of Object.entries(v)) {
+			if (typeof val === "string") out[k] = val;
+		}
+	}
+	return out;
+}
+
+// Parse an unknown blob into a known-good ControlSnapshot, dropping any field or
+// entry that does not match the declared shape. The returned value is a real
+// proof of its type — every map is an object, every value the right primitive —
+// so the restore paths below need no further shape guards. Returns null only
+// when the top level is not an object.
+function parseSnapshot(raw: unknown): ControlSnapshot | null {
+	if (typeof raw !== "object" || raw === null) return null;
+	const o = raw as Record<string, unknown>;
+	const inputs: Record<string, string | boolean> = {};
+	if (typeof o.inputs === "object" && o.inputs !== null) {
+		for (const [k, val] of Object.entries(o.inputs)) {
+			if (typeof val === "string" || typeof val === "boolean") inputs[k] = val;
+		}
+	}
+	return {
+		inputs,
+		groups: parseStringMap(o.groups),
+		material: typeof o.material === "string" ? o.material : DEFAULT_MATERIAL,
+		colors: parseStringMap(o.colors),
+	};
+}
+
+// Best-effort read, then parse (not cast) at the storage boundary. A
+// missing/unparseable/throwing access -> null (fall back to markup defaults);
+// a present blob is normalized to a valid snapshot by parseSnapshot.
+function readSnapshot(): ControlSnapshot | null {
+	try {
+		const raw = localStorage.getItem(STORAGE_KEY);
+		if (!raw) return null;
+		return parseSnapshot(JSON.parse(raw));
+	} catch {
+		return null;
+	}
+}
+
+// Best-effort write. A disabled or full store is swallowed.
+function writeSnapshot(snap: ControlSnapshot): void {
+	try {
+		localStorage.setItem(STORAGE_KEY, JSON.stringify(snap));
+	} catch {
+		// ignore: storage disabled or over quota
+	}
+}
+
+// Best-effort clear of just the persistence key.
+function clearSnapshot(): void {
+	try {
+		localStorage.removeItem(STORAGE_KEY);
+	} catch {
+		// ignore: storage disabled
+	}
+}
+
 export function initControls(): { getConfig: () => Config } {
 	let cfg: Config = {
 		speed: 1,
@@ -44,6 +121,62 @@ export function initControls(): { getConfig: () => Config } {
 	// Panel open/close
 	const gear = document.getElementById("gear") as HTMLButtonElement;
 	const panel = document.getElementById("controls") as HTMLDivElement;
+
+	// Persistence: restore the saved drawer snapshot onto the DOM controls BEFORE
+	// the bind/apply pass below replays initial values, so binds observe the
+	// restored DOM rather than the markup defaults. A null snapshot (first visit,
+	// disabled storage, or unparseable blob) leaves markup defaults in place.
+	const restored = readSnapshot();
+
+	// Write each persisted input/group/color value back onto its DOM control.
+	// Material is handled separately at applyMaterial (it has its own var/picker
+	// seeding). Per-control: skip any id absent from this DOM version.
+	function applySnapshot(snap: ControlSnapshot) {
+		for (const [id, v] of Object.entries(snap.inputs)) {
+			const el = document.getElementById(id) as HTMLInputElement | null;
+			if (!el) continue;
+			if (el.type === "checkbox") el.checked = Boolean(v);
+			else el.value = String(v);
+		}
+		for (const [id, v] of Object.entries(snap.groups)) {
+			const grp = document.getElementById(id);
+			if (grp) grp.dataset.value = v;
+		}
+	}
+	if (restored) applySnapshot(restored);
+
+	// Read the live drawer state into a snapshot. Reads only named control handles
+	// (inputs by id, groups by dataset.value, the active material swatch, color
+	// pickers by data-var), so simulation state is excluded by construction.
+	function captureSnapshot(): ControlSnapshot {
+		const inputs: Record<string, string | boolean> = {};
+		for (const inp of panel.querySelectorAll<HTMLInputElement>(
+			"input[id]:not([type=color])",
+		)) {
+			if (inp.type === "checkbox") inputs[inp.id] = inp.checked;
+			else inputs[inp.id] = inp.value;
+		}
+		const groups: Record<string, string> = {};
+		for (const grp of panel.querySelectorAll<HTMLElement>(".btn-group[id]")) {
+			if (grp.dataset.value !== undefined) groups[grp.id] = grp.dataset.value;
+		}
+		const active = panel.querySelector<HTMLButtonElement>(
+			"button.material-swatch.active",
+		);
+		const material = active?.dataset.material ?? DEFAULT_MATERIAL;
+		const colors: Record<string, string> = {};
+		for (const inp of panel.querySelectorAll<HTMLInputElement>(
+			"input[type=color][data-var]",
+		)) {
+			if (inp.dataset.var) colors[inp.dataset.var] = inp.value;
+		}
+		return { inputs, groups, material, colors };
+	}
+
+	// Write-on-change persistence writer.
+	function persist() {
+		writeSnapshot(captureSnapshot());
+	}
 
 	function togglePanel(open?: boolean) {
 		const o = open ?? !panel.classList.contains("open");
@@ -238,7 +371,54 @@ export function initControls(): { getConfig: () => Config } {
 			applyMaterial(b.dataset.material as MaterialId),
 		);
 	}
-	applyMaterial(DEFAULT_MATERIAL);
+
+	// Seed the material: the restored one if a snapshot exists and names a known
+	// swatch, otherwise the default. applyMaterial re-seeds the material-driven
+	// color pickers, so any persisted per-picker overrides (e.g. --ground, the
+	// independent --strap-leather) must be layered AFTER, matching the existing
+	// "advanced override" behavior.
+	const restoredMaterial = restored?.material;
+	const hasSwatch = Array.from(matBtns).some(
+		(b) => b.dataset.material === restoredMaterial,
+	);
+	applyMaterial(
+		hasSwatch ? (restoredMaterial as MaterialId) : DEFAULT_MATERIAL,
+	);
+	if (restored?.colors) {
+		for (const inp of colorInputs) {
+			const varName = inp.dataset.var;
+			if (varName && varName in restored.colors) {
+				inp.value = restored.colors[varName];
+				document.documentElement.style.setProperty(varName, inp.value);
+			}
+		}
+	}
+
+	// Persistence: write the current snapshot on every control change. Listeners
+	// attach directly to each control rather than relying on event delegation,
+	// because the synthetic input/change events controls dispatch (here and in
+	// tests) do not bubble. Color/material changes flow through the color picker
+	// inputs; group choices flow through their buttons. No simulation state is
+	// ever read by captureSnapshot, so the snapshot stays controls-only.
+	for (const inp of panel.querySelectorAll<HTMLInputElement>("input[id]")) {
+		inp.addEventListener("input", persist);
+		inp.addEventListener("change", persist);
+	}
+	for (const inp of colorInputs) {
+		inp.addEventListener("input", persist);
+	}
+	// Same generic selector captureSnapshot uses, so a future fourth group is
+	// both captured and write-triggered without touching a second hardcoded list.
+	for (const grp of panel.querySelectorAll<HTMLElement>(".btn-group[id]")) {
+		for (const b of grp.querySelectorAll<HTMLButtonElement>(
+			"button[data-value]",
+		)) {
+			b.addEventListener("click", persist);
+		}
+	}
+	for (const b of matBtns) {
+		b.addEventListener("click", persist);
+	}
 
 	// Reset button
 	document.getElementById("resetBtn")?.addEventListener("click", () => {
@@ -269,6 +449,10 @@ export function initControls(): { getConfig: () => Config } {
 		setChk("parallaxOn", false);
 		earthGroup.set("galilean");
 		caseGroup.set("full");
+		// Clear last: the default-applying dispatches above synchronously
+		// re-trigger the persistence writer, so removing the key here leaves
+		// storage truly empty after a Reset.
+		clearSnapshot();
 	});
 
 	return { getConfig: () => ({ ...cfg }) };

--- a/src/components/astrolabe/persistence.feature.test.ts
+++ b/src/components/astrolabe/persistence.feature.test.ts
@@ -1,0 +1,154 @@
+// @vitest-environment jsdom
+
+// Feature test for Astrolabe controls persistence: the controls-drawer state is
+// saved to localStorage and restored on reload, while the simulation always
+// boots fresh and Reset wipes the persisted snapshot. Red until persistence
+// lands in controls.ts. See
+// .ailly/developer/2026-06-17-A-astrolabe-persistence/design.md.
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import page from "../../../pages/astrolabe/page.ts";
+import { KEPLERIAN } from "../../lib/astrolabe/types.ts";
+import { mount, resetDom } from "../test-dom.ts";
+import { initControls } from "./controls.ts";
+
+const STORAGE_KEY = "astrolabe.controls.v1";
+
+afterEach(() => {
+	resetDom();
+	localStorage.clear();
+});
+
+// Drive a representative control off its default: a segmented group, a slider,
+// a checkbox, a material swatch, and a color picker. Mirrors how a user touches
+// the drawer. Returns the values set so the reload assertions can compare.
+function changeRepresentativeControls() {
+	// Segmented group: Earth frame -> Keplerian (default galilean).
+	const keplerianBtn = document.querySelector<HTMLButtonElement>(
+		'#earthMode button[data-value="keplerian"]',
+	);
+	keplerianBtn?.click();
+
+	// Range slider: parallax strength -> 1.20 (default 0.70).
+	const parallax = document.getElementById("parallax") as HTMLInputElement;
+	parallax.value = "1.2";
+	parallax.dispatchEvent(new Event("input"));
+
+	// Checkbox: disc arms on (default off).
+	const spokes = document.getElementById("t_spokes") as HTMLInputElement;
+	spokes.checked = true;
+	spokes.dispatchEvent(new Event("change"));
+
+	// Material swatch: Gold (default platinum). Gold's --case is #d9a441.
+	const gold = document.querySelector<HTMLButtonElement>(
+		'button.material-swatch[data-material="gold"]',
+	);
+	gold?.click();
+
+	// Color picker: the background (--ground), an advanced override.
+	const ground = document.querySelector<HTMLInputElement>(
+		'input[type=color][data-var="--ground"]',
+	);
+	if (ground) {
+		ground.value = "#123456";
+		ground.dispatchEvent(new Event("input"));
+	}
+}
+
+describe("astrolabe controls persistence", () => {
+	beforeEach(() => {
+		localStorage.clear();
+	});
+
+	it("restores the changed controls across a reload", () => {
+		// Arrange: first visit — mount, init, change a representative set.
+		mount(page.default());
+		const first = initControls();
+		changeRepresentativeControls();
+		expect(first.getConfig().earthMode).toBe(KEPLERIAN);
+
+		// Act: simulate a reload — tear down the DOM but KEEP localStorage, then
+		// re-mount and re-init exactly as a fresh page load would.
+		resetDom();
+		mount(page.default());
+		const second = initControls();
+
+		// Assert: the controls came back with the changed values...
+		const earthMode = document.getElementById("earthMode") as HTMLElement;
+		expect(earthMode.dataset.value).toBe("keplerian");
+
+		const parallax = document.getElementById("parallax") as HTMLInputElement;
+		expect(parseFloat(parallax.value)).toBeCloseTo(1.2, 5);
+
+		const spokes = document.getElementById("t_spokes") as HTMLInputElement;
+		expect(spokes.checked).toBe(true);
+
+		const ground = document.querySelector<HTMLInputElement>(
+			'input[type=color][data-var="--ground"]',
+		);
+		expect(ground?.value.toLowerCase()).toBe("#123456");
+
+		// ...the chosen material's accent var is applied to the root...
+		expect(
+			document.documentElement.style
+				.getPropertyValue("--case")
+				.trim()
+				.toLowerCase(),
+		).toBe("#d9a441");
+
+		// ...and getConfig() reflects the restored choices.
+		const cfg = second.getConfig();
+		expect(cfg.earthMode).toBe(KEPLERIAN);
+		expect(cfg.parallax).toBeCloseTo(1.2, 5);
+	});
+
+	it("clears the persisted snapshot when Reset is clicked", () => {
+		mount(page.default());
+		initControls();
+		changeRepresentativeControls();
+		// Something is persisted before reset.
+		expect(localStorage.getItem(STORAGE_KEY)).not.toBeNull();
+
+		(document.getElementById("resetBtn") as HTMLButtonElement).click();
+
+		// Reset leaves storage truly empty: the persistence key is gone.
+		expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+	});
+
+	it("survives a malformed stored blob by falling back to defaults", () => {
+		// A tampered/stale store where the typed shape is violated: `colors` is a
+		// string, not a map. A cast would let this through and crash init at the
+		// first `var in colors` (TypeError on a primitive). Parsing at the boundary
+		// normalizes it instead, so init proceeds on markup defaults.
+		localStorage.setItem(
+			STORAGE_KEY,
+			JSON.stringify({ inputs: "nope", groups: 5, material: 42, colors: "x" }),
+		);
+
+		mount(page.default());
+		expect(() => initControls()).not.toThrow();
+
+		// Nothing from the bad blob leaked in: the Earth frame is the markup default.
+		const earthMode = document.getElementById("earthMode") as HTMLElement;
+		expect(earthMode.dataset.value).toBe("galilean");
+	});
+
+	it("persists only controls state, never the simulation", () => {
+		mount(page.default());
+		initControls();
+		changeRepresentativeControls();
+
+		// The persistence key is the only astrolabe key in storage.
+		const astrolabeKeys = Object.keys(localStorage).filter((k) =>
+			k.startsWith("astrolabe"),
+		);
+		expect(astrolabeKeys).toEqual([STORAGE_KEY]);
+
+		// The stored snapshot carries no simulation fields.
+		const raw = localStorage.getItem(STORAGE_KEY);
+		expect(raw).not.toBeNull();
+		const flat = JSON.stringify(JSON.parse(raw as string));
+		for (const simField of ["simT", "bootMs", "caseOffset"]) {
+			expect(flat).not.toContain(simField);
+		}
+	});
+});


### PR DESCRIPTION
Save the controls drawer's per-control DOM state to localStorage under
astrolabe.controls.v1 and restore it on init by driving the existing
bind/apply paths, so preferences survive a reload while the simulation
boots fresh. Reset clears the persisted key. Storage access is
best-effort; simulation state is excluded by construction.

Co-Authored-By: Ailly <developer@ailly.dev>

refactor(astrolabe): parse the persisted snapshot at the storage boundary

readSnapshot cast the parsed JSON to ControlSnapshot after only a top-level
object check, so a tampered or stale blob could carry a non-object `colors`
and crash initControls at `var in restored.colors` (TypeError on a primitive).

Parse instead of validate: parseSnapshot normalizes the unknown blob into a
known-good ControlSnapshot, dropping any field or entry that violates the
declared shape. The returned value is a real proof of its type, so the restore
paths drop their `?? {}` guards. Adds a feature test covering a malformed blob.

Co-Authored-By: Ailly <developer@ailly.dev>
